### PR TITLE
saving revamp based on portfolio experience/formatting

### DIFF
--- a/src/Pages/Portfolio.razor
+++ b/src/Pages/Portfolio.razor
@@ -3,6 +3,7 @@
 @inject HttpClient Http
 @inject IFamilyYears familyYears
 @inject IJSRuntime JSRuntime
+@inject NavigationManager Navigation
 
 <PageTitle>
 portfolio/@stepPath
@@ -109,7 +110,7 @@ portfolio/@stepPath
                                                 <span>&nbsp;&nbsp;@debt.Name: @formatMoney(debt.Total) @@ @(debt.Rate == null ? "unknown" : debt.Rate)%</span><br/> 
                                             }
                                         }
-                                        <br/><br/>
+                                        <br/>
                                     </td>
                                     break;
                                 case "tax-status":
@@ -175,10 +176,19 @@ portfolio/@stepPath
                                             <br/>
                                     </td>
                                     break;
+                                case "additional-background":
+                                    @((MarkupString)boldUnderline("Additional Background:"))<br/>
+                                    @familyYears.Active.AdditionalBackground
+                                    <br/>
+                                    break;
                                 case "questions":
                                     <td>
                                         @((MarkupString)boldUnderline("Questions:"))<br/>
-                                        <br/>
+                                        @for (int i = 0; i < familyYears.Active.Questions.Count; i++) {
+                                            var question = familyYears.Active.Questions[i];
+                                            @(i+1 + ".") @question
+                                            <br/><br/>
+                                        }
                                     </td>
                                     break;
                                 case "contributions":
@@ -365,10 +375,10 @@ portfolio/@stepPath
                                     <select @bind=familyYears.Active.TaxFilingStatus>
                                         <option value=None>choose...</option>
                                         <option>Single</option>
-                                        <option value=HeadOfHousehold>Head of Household</option>
                                         <option value=MarriedFilingJointly>Married filing jointly</option>
                                         <option value=MarriedFilingSeperately>Married filing seperately</option>
                                         <option value=MarriedFilingSeperatelyAndLivingApart>Married filing seperately (and living apart)</option>
+                                        <option value=HeadOfHousehold>Head of Household</option>
                                     </select><br/>
                                     @foreach (var taxFiler in familyYears.Active.TaxRateData.TaxData.TaxFilers)
                                     {
@@ -423,26 +433,28 @@ portfolio/@stepPath
                                 <select @bind=familyYears.Active.TaxFilingStatus>
                                     <option value=None>choose...</option>
                                     <option>Single</option>
-                                    <option value=HeadOfHousehold>Head of Household</option>
                                     <option value=MarriedFilingJointly>Married filing jointly</option>
                                     <option value=MarriedFilingSeperately>Married filing seperately</option>
                                     <option value=MarriedFilingSeperatelyAndLivingApart>Married filing seperately (and living apart)</option>
+                                    <option value=HeadOfHousehold>Head of Household</option>
                                 </select><br/><br/>
                                 
                                 <p><b>Worksheet:</b> </p>
                                 @for (int i = 0; i < familyYears.Active.PersonCount; i++) {
                                     var person = familyYears.Active.People[i];
-                                    <p><b>Person @(i+1):</b> </p>
+                                    int personIndex = i + 1;
+                                    <p><b>Person @personIndex:</b> </p>
 
                                     <EditForm Model="person" style=margin-left:25px>
-                                        <label>Age:</label> <input type=text @bind-Value=person.Age @bind-Value:event=oninput /><br/>
+                                        <label>Age:</label> <input style=width:60px type=text @bind-Value=person.Age @bind-Value:event=oninput /><br/>
 
                                         <label>Pronoun/Unique identifier:</label> <select @bind=person.Identifier>
                                             <option value=None>choose...</option>
-                                            <option>me</option>
-                                            <option>them</option>
+                                            <option>person @personIndex</option>
                                             <option>him</option>
                                             <option>her</option>
+                                            <option>me</option>
+                                            <option>them</option>
                                         </select><br/><br/>
                                     </EditForm><br/>
                                 }
@@ -490,14 +502,32 @@ portfolio/@stepPath
                                             </div>
                                         }
                                         <br/>
-                                        <br/>
                                         <button style=margin-left:80px @onclick='@(e=>addAvailableFund(e,currentAccount))'>➕ Fund</button>
                                     }
                                 </td>
                                 break;
+                            case "additional-background":
+                                <td>
+                                    <textarea style=width:600px;height:300px @bind-Value=familyYears.Active.AdditionalBackground @bind-Value:event=oninput placeholder='additional background information'>
+                                        @familyYears.Active.AdditionalBackground
+                                    </textarea>
+                                </td>
+                                break;
                             case "questions":
                                 <td>
-                                    More coming soon...
+                                    @for (int i = 0; i < familyYears.Active.Questions.Count; i++) {
+                                        int iBuffer = i;
+                                        @(i+1 + ".") <input type=text @bind-Value=familyYears.Active.Questions[iBuffer] @bind-Value:event="oninput" placeholder="ask question" /><br/>
+                                        <br/>
+                                    }
+                                    <br/>
+                                        <button style=margin-left:80px @onclick=addQuestion>➕ Question</button>
+                                    <br/>
+                                    @code {
+                                        void addQuestion() {
+                                            familyYears.Active.Questions.Add("");
+                                        }
+                                    }
                                 </td>
                                 break;                                
                             case "retirement-assets":
@@ -507,14 +537,14 @@ portfolio/@stepPath
                                 <select @bind=familyYears.Active.TaxFilingStatus>
                                     <option value=None>choose...</option>
                                     <option>Single</option>
-                                    <option value=HeadOfHousehold>Head of Household</option>
                                     <option value=MarriedFilingJointly>Married filing jointly</option>
                                     <option value=MarriedFilingSeperately>Married filing seperately</option>
                                     <option value=MarriedFilingSeperatelyAndLivingApart>Married filing seperately (and living apart)</option>
+                                    <option value=HeadOfHousehold>Head of Household</option>
                                 </select><br/>
                                 <br/>
 
-                                <u><b>Current Retirement Assets:</b></u><br/><br/>
+                                <u><b>Current Retirement Assets:</b></u><br/>
 
                                 @code{
                                     void editAccount(MouseEventArgs e, int index)
@@ -614,9 +644,7 @@ portfolio/@stepPath
                                 }
                                 break;
                             case "contributions":
-                                <p><b>Worksheet:</b> </p>
-
-                                
+                                Navigation.NavigateTo("/portfolio-contributions");        
                                 break;
                         }
                     <p>

--- a/src/Pages/Saving.razor
+++ b/src/Pages/Saving.razor
@@ -1,5 +1,6 @@
 ﻿@page "/saving"
 @page "/saving/{stepPath}"
+@page "/portfolio-contributions"
 @inject HttpClient Http
 @inject IFamilyYears familyYears
 
@@ -65,111 +66,157 @@ saving/@stepPath
                 <p ><b>Prerequisities:</b></p>
                 <EditForm Model="familyYears.Active" style=margin-left:25px>
                     <label>Target Year:</label> <select @bind=familyYears.CurrentYear><option value=0>2022</option><option value=1>2023</option></select><br/>
-                    <label>Estimated Adjusted Gross Income:</label> $<input type=text class=dollar @bind-Value=familyYears.Active.AdjustedGrossIncome @bind-Value:event=oninput /><br/><br/>
-                </EditForm>
-                
-                <p ><b>Steps:</b></p>
+                    <label>Tax Filing Status:</label>
+                    <select @bind=familyYears.Active.TaxFilingStatus>
+                        <option value=None>choose...</option>
+                        <option>Single</option>
+                        <option value=MarriedFilingJointly>Married filing jointly</option>
+                        <option value=MarriedFilingSeperately>Married filing seperately</option>
+                        <option value=MarriedFilingSeperatelyAndLivingApart>Married filing seperately (and living apart)</option>
+                        <option value=HeadOfHousehold>Head of Household</option>
+                    </select><br/>
+                    @for (int i = 0; i < familyYears.Active.PersonCount; i++) {
+                        var person = familyYears.Active.People[i];
+                        <span>Person @(i+1):</span><br/>
+                        <div style=margin-left:25px>
+                            <label>Age:</label> <input style=width:60px type=text @bind-Value=person.Age @bind-Value:event=oninput /><br/>
 
+                            <label>Pronoun/Unique identifier:</label> <select @bind=person.Identifier>
+                                <option value=None>choose...</option>
+                                <option>person @(i+1)</option>
+                                <option>him</option>
+                                <option>her</option>
+                                <option>me</option>
+                                <option>them</option>
+                            </select><br/>
+                        </div>
+                    }
+                    <label>Estimated Adjusted Gross Income:</label> $<input type=text class=dollar @bind-Value=familyYears.Active.AdjustedGrossIncome @bind-Value:event=oninput /><br/>
+                    <label>Monthly Expenses:</label> <span>$</span><input class=dollar type=text @bind-Value="familyYears.Active.EmergencyFund.MonthlyExpenses" @bind-Value:event="oninput" /><br/>
+                    <label>Annual Income Tax Paid:</label> <span>$</span><input class=dollar type=text @bind-Value="familyYears.Active.IncomeTaxPaid" @bind-Value:event="oninput" /><br/>
+                    <label>Money in Taxable Fund, to help invest more:</label> <span>$</span><input class=dollar type=text @bind-Value="familyYears.Active.TaxableToInvest" @bind-Value:event="oninput" /><br/>
+                    <label>Planned Savings:</label> <span>@formatMoney(familyYears.Active.PlannedSavings)</span><br/>
+                </EditForm>
+                <br/>
+                <p ><b>Prioritized Steps:</b></p>
+
+                <p><b>Press edit (✏️) to complete each step:</b></p>
                 <table>
-                    <thead>
-                        <th colspan=2>Press edit (✏️) to complete each step:</th>
-                        @if(familyYears.Active.PersonCount > 0) {<th style="padding-right:10px;text-align:center">$</th> }
-                        @if(familyYears.Active.PersonCount > 0) {<th style="padding-right:10px;text-align:center">Match</th> }
-                        <th>&nbsp;</th>
-                        <th>&nbsp;</th>
-                    </thead>
-  
                     @foreach (var step in steps) {
                         var href = folderName + @step.step;
                         <tr>
-                            <td>
-                                <div>
-                                    @step.number <a href="@href" style="background:blue" class="m-1 btn" >✏️</a>
-                                </div>
+                            <td style=text-align:right>
+                                @step.number
                             </td>
                             <td>
-                                <b>@step.title:</b>
+                                <a href="@href" style="background:blue" class="m-1 btn" >✏️</a>
                             </td>
                             @switch (step.step) {
                                 case "emergency-fund": 
-                                   <td style=text-align:center>@familyYears.Active.EmergencyFund.AmountToSave</td><td></td>
+                                    <td>
+                                        @if (familyYears.Active.EmergencyFund.AmountToSave != null) {
+                                            <span>@formatMoney(familyYears.Active.EmergencyFund.AmountToSave) in Emergency Fund</span><br/>
+                                        } else {
+                                            <b>@step.title</b>
+                                        }
+                                    </td>
                                    break;
                                 case "retirement-funds-match":
-                                   <td style=text-align:center>
-                                        @familyYears.Active.People[0].EmployerPlan.AmountToSaveForMatch<br/>
-                                        @if(familyYears.Active.PersonCount > 1 && familyYears.Active.People[1].EmployerPlan.AmountToSaveForMatch != null) {
-                                            <span>Person2: @familyYears.Active.People[1].EmployerPlan.AmountToSaveForMatch</span>
+                                    <td>
+                                        @if (familyYears.Active.People[0].EmployerPlan.AmountToSaveForMatch > 0) {
+                                            <span>@formatMoney(familyYears.Active.People[0].EmployerPlan.AmountToSaveForMatch) in @familyYears.Active.People[0].PossessiveID 401k (Match: @formatMoney(familyYears.Active.People[0].EmployerPlan.MatchAmount))</span><br/>
                                         }
-                                   </td>
-                                   <td style=text-align:center>
-                                        @familyYears.Active.People[0].EmployerPlan.MatchAmount<br/>
-                                        @familyYears.Active.People[1].EmployerPlan.MatchAmount
-                                   </td>
+                                        @if (familyYears.Active.People[1].EmployerPlan.AmountToSaveForMatch > 0) {
+                                            <span>@formatMoney(familyYears.Active.People[1].EmployerPlan.AmountToSaveForMatch) in @familyYears.Active.People[1].PossessiveID 401k (Match: @formatMoney(familyYears.Active.People[1].EmployerPlan.MatchAmount))</span><br/>
+                                        }
+                                        @if (familyYears.Active.People[0].EmployerPlan.AmountToSaveForMatch == null && familyYears.Active.People[1].EmployerPlan.AmountToSaveForMatch == null) {
+                                            <b>@step.title</b>
+                                        }
+                                    </td>
                                    break;
                                 case "high-interest-debt":
-                                    <td style=text-align:center>
-                                        @familyYears.Active.HighDebts
+                                    <td>
+                                        @if (familyYears.Active.Debts.Count > 0) {
+                                            <span>@formatMoney(familyYears.Active.HighDebts>0?familyYears.Active.HighDebts:0) in High-Interest Debts</span><br/>
+                                        } else {
+                                            <b>@step.title</b>
+                                        }
                                     </td>
                                     break;
-                                case "hsa": 
-                                    <td style=text-align:center>
-                                        @familyYears.Active.People[0].HealthSavingsAccount.AmountToSave<br/>
-                                        @if(familyYears.Active.PersonCount > 1 && familyYears.Active.People[1].HealthSavingsAccount.AmountToSave != null) {
-                                            <span>Person2: @familyYears.Active.People[1].HealthSavingsAccount.AmountToSave</span>
+                                case "hsa":
+                                    <td>
+                                        @if (familyYears.Active.People[0].HealthSavingsAccount.AmountToSave > 0) {
+                                            <span>@formatMoney(familyYears.Active.People[0].HealthSavingsAccount.AmountToSave) in @familyYears.Active.People[0].PossessiveID HSA (Employer: @formatMoney(familyYears.Active.People[0].HealthSavingsAccount.EmployerContribution))</span><br/>
                                         }
-                                    </td>
-                                    <td style=text-align:center>
-                                        @if(familyYears.Active.People[0].HealthSavingsAccount.Eligible) {
-                                            @familyYears.Active.People[0].HealthSavingsAccount.EmployerContribution
+                                        @if (familyYears.Active.People[1].HealthSavingsAccount.AmountToSave > 0) {
+                                            <span>@formatMoney(familyYears.Active.People[1].HealthSavingsAccount.AmountToSave) in @familyYears.Active.People[1].PossessiveID HSA (Employer: @formatMoney(familyYears.Active.People[1].HealthSavingsAccount.EmployerContribution))</span><br/>
                                         }
-                                        <br/>
-                                        @if(familyYears.Active.People[1].HealthSavingsAccount.Eligible) {
-                                            @familyYears.Active.People[1].HealthSavingsAccount.EmployerContribution
+                                        @if (familyYears.Active.People[0].HealthSavingsAccount.AmountToSave == null && familyYears.Active.People[1].HealthSavingsAccount.AmountToSave == null) {
+                                            <b>@step.title</b>
                                         }
-                                        
                                     </td>
                                    break;
                                 case "ira-or-roth-ira":
-                                    <td style=text-align:left colspan="5">
-                                    @if (familyYears.Active.AdjustedGrossIncome != null) {
-                                        if (familyYears.Active.PersonCount > 0) {
-                                            <span>@((MarkupString)GetRecommendedIRAMarkup(familyYears.Active.People[0]))</span><br/>
+                                    <td>
+                                        @if (familyYears.Active.AdjustedGrossIncome != null) {
+                                            if (familyYears.Active.PersonCount > 0) {
+                                                <span>@((MarkupString)GetRecommendedIRAMarkup(familyYears.Active.People[0]))</span><br/>
+                                            }
+                                            if(familyYears.Active.PersonCount > 1) {
+                                                <span>@((MarkupString)GetRecommendedIRAMarkup(familyYears.Active.People[1]))</span><br/>
+                                            }
+                                        } else {
+                                            <b>@step.title</b>
                                         }
-                                        if(familyYears.Active.PersonCount > 1) {
-                                            <span>Person2: @((MarkupString)GetRecommendedIRAMarkup(familyYears.Active.People[1]))</span>
-                                        }
-                                    }
                                     </td>
                                     break;
                                 case "employer-retirement-funds": 
-                                    <td style=text-align:center>
-                                        @familyYears.Active.People[0].EmployerPlan.AmountToSaveForNonMatched<br/>
-                                        @if(familyYears.Active.PersonCount > 1 && familyYears.Active.People[1].EmployerPlan.AmountToSaveForNonMatched != null) {
-                                            <span>Person2: @familyYears.Active.People[1].EmployerPlan.AmountToSaveForNonMatched</span>
+                                    <td>
+                                        @if (familyYears.Active.People[0].EmployerPlan.AmountToSaveForNonMatched > 0) {
+                                            <span>@formatMoney(familyYears.Active.People[0].EmployerPlan.AmountToSaveForNonMatched) in @familyYears.Active.People[0].PossessiveID 401k</span><br/>
+                                        }
+                                        @if (familyYears.Active.People[1].EmployerPlan.AmountToSaveForNonMatched > 0) {
+                                            <span>@formatMoney(familyYears.Active.People[1].EmployerPlan.AmountToSaveForNonMatched) in @familyYears.Active.People[1].PossessiveID 401k</span><br/>
+                                        }
+                                        @if (familyYears.Active.People[0].EmployerPlan.AmountToSaveForNonMatched == null && familyYears.Active.People[1].EmployerPlan.AmountToSaveForNonMatched == null) {
+                                            <b>@step.title</b>
                                         }
                                     </td>
                                     break;
                                 case "mega-backdoor-roth": 
-                                   <td style=text-align:center>
-                                        @familyYears.Active.People[0].EmployerPlan.AmountToSaveForBackdoorRoth<br/>
-                                        @if(familyYears.Active.PersonCount > 1 && familyYears.Active.People[1].EmployerPlan.AmountToSaveForBackdoorRoth != null) {
-                                            <span>Person2: @familyYears.Active.People[1].EmployerPlan.AmountToSaveForBackdoorRoth</span>
+                                    <td>
+                                        @if (familyYears.Active.People[0].EmployerPlan.AmountToSaveForBackdoorRoth > 0) {
+                                            <span>@formatMoney(familyYears.Active.People[0].EmployerPlan.AmountToSaveForBackdoorRoth) in @familyYears.Active.People[0].PossessiveID mega backdoor roth</span><br/>
                                         }
-                                   </td>
+                                        @if (familyYears.Active.People[1].EmployerPlan.AmountToSaveForBackdoorRoth > 0) {
+                                            <span>@formatMoney(familyYears.Active.People[1].EmployerPlan.AmountToSaveForBackdoorRoth) in @familyYears.Active.People[1].PossessiveID mega backdoor roth</span><br/>
+                                        }
+                                        @if (familyYears.Active.People[0].EmployerPlan.AmountToSaveForBackdoorRoth == null && familyYears.Active.People[1].EmployerPlan.AmountToSaveForBackdoorRoth == null) {
+                                            <b>@step.title</b>
+                                        }
+                                    </td>
                                    break;
                                 case "medium-interest-debt":
-                                    <td style=text-align:center>
-                                        @familyYears.Active.MediumDebts
+                                    <td>
+                                        @if (familyYears.Active.Debts.Count > 0) {
+                                                <span>@formatMoney(familyYears.Active.MediumDebts>0?familyYears.Active.MediumDebts:0) in Medium-Interest Debts</span><br/>
+                                        } else {
+                                            <b>@step.title</b>
+                                        }
                                     </td>
                                     break;
                                 case "taxable-accounts": 
-                                    <td style=text-align:center>
-                                        @if(familyYears.Active.PersonCount > 0) {<span>no limits</span> }
+                                    <td>
+                                        "no limit" in Taxable
                                     </td>
                                     break;                                                                   
                                 case "low-interest-debt":
-                                    <td style=text-align:center>
-                                        @familyYears.Active.LowDebts
+                                    <td>
+                                        @if (familyYears.Active.Debts.Count > 0) {
+                                                <span>@formatMoney(familyYears.Active.LowDebts>0?familyYears.Active.LowDebts:0) in Low-Interest Debts</span><br/>
+                                        } else {
+                                            <b>@step.title</b>
+                                        }
                                     </td>
                                     break;
                                 default:
@@ -228,14 +275,14 @@ saving/@stepPath
                                     <label>Planned size of emergency fund:</label><br/>
                                     <InputRadioGroup @bind-Value=familyYears.Active.EmergencyFund.TargetMonths>
                                         <InputRadio Value='0'/> None<br/>
-                                        <InputRadio Value='1'/> 1 month: $@familyYears.Active.EmergencyFund.MonthlyExpenses<br/>
-                                        <InputRadio Value='3'/> 3 months: $@familyYears.Active.EmergencyFund.ThreeMonths<br/>
+                                        <InputRadio Value='1'/> 1 month: @formatMoney(familyYears.Active.EmergencyFund.MonthlyExpenses)<br/>
+                                        <InputRadio Value='3'/> 3 months: @formatMoney(familyYears.Active.EmergencyFund.ThreeMonths)<br/>
                                         <InputRadio Value='4'/> Other: <br/>
                                     </InputRadioGroup>
-                                    <div style="margin-left:20px">$<input type=text class=dollar @bind-Value="familyYears.Active.EmergencyFund.EFOther" @bind-Value:event="oninput"/></div>
+                                    <div style="margin-left:20px">$<input type=text class=dollar @bind-Value="familyYears.Active.EmergencyFund.EFOther" @bind-Value:event="oninput" /></div>
                                     <br/>
-                                    <label>Current Size:</label> <span>$</span><input class=dollar type=text @bind-Value="familyYears.Active.EmergencyFund.CurrentBalance" @bind-Value:event="oninput"/><br/><br/>
-                                    <label>Amount to Save:</label> <span>$</span>@familyYears.Active.EmergencyFund.AmountToSave<br/>
+                                    <label>Current Size:</label> <span>$</span><input class=dollar type=text @bind-Value="familyYears.Active.EmergencyFund.CurrentBalance" @bind-Value:event="oninput" /><br/><br/>
+                                    <label>Amount to Save:</label> @formatMoney(familyYears.Active.EmergencyFund.AmountToSave)<br/>
                                 </EditForm><br/>
                                 break;
                             case 2:
@@ -246,10 +293,10 @@ saving/@stepPath
                                     <label>Tax Filing Status:</label> <select @bind=familyYears.Active.TaxFilingStatus>
                                         <option value=None>choose...</option>
                                         <option>Single</option>
-                                        <option value=HeadOfHousehold>Head of Household</option>
                                         <option value=MarriedFilingJointly>Married filing jointly</option>
                                         <option value=MarriedFilingSeperately>Married filing seperately</option>
                                         <option value=MarriedFilingSeperatelyAndLivingApart>Married filing seperately (and living apart)</option>
+                                        <option value=HeadOfHousehold>Head of Household</option>
                                         </select><br/>
                                 </EditForm><br/>
                                 @for (int i = 0; i < familyYears.Active.PersonCount; i++) {
@@ -269,13 +316,12 @@ saving/@stepPath
                                             <label>Match B:</label> <input type=text class=percent @bind-Value=person.EmployerPlan.MatchB @bind-Value:event=oninput />%
                                             <label margin-left:30px>for next</label> <input type=text class=percent @bind-Value=person.EmployerPlan.MatchBLimit @bind-Value:event=oninput/>%<br/>
                                             <label>Max Match:</label> $<input type=text class=dollar @bind-Value=person.EmployerPlan.MaxMatch @bind-Value:event=oninput/><br/>
-                                            <label>Contribution required to get maximum match:</label> $<span>@person.EmployerPlan.AmountToSaveForMatch</span><br/>
-                                            <label>Match Amount:</label> $<span>@person.EmployerPlan.MatchAmount</span><br/>
+                                            <label>Contribution required to get maximum match:</label> <span>@formatMoney(person.EmployerPlan.AmountToSaveForMatch)</span><br/>
+                                            <label>Match Amount:</label> <span>@formatMoney(person.EmployerPlan.MatchAmount)</span><br/>
                                         </fieldset>
                                         }
                                     </EditForm><br/>
                                 }
-
                                 break;
                             case 4:
                                 <p><b>Prerequisities:</b> </p>
@@ -285,25 +331,24 @@ saving/@stepPath
                                     <label>Tax Filing Status:</label> <select @bind=familyYears.Active.TaxFilingStatus>
                                                 <option value=None>choose...</option>
                                                 <option>Single</option>
-                                                <option value=HeadOfHousehold>Head of Household</option>
                                                 <option value=MarriedFilingJointly>Married filing jointly</option>
                                                 <option value=MarriedFilingSeperately>Married filing seperately</option>
                                                 <option value=MarriedFilingSeperatelyAndLivingApart>Married filing seperately (and living apart)</option>
+                                                <option value=HeadOfHousehold>Head of Household</option>
                                                 </select><br/>
                                 </EditForm><br/>
                                 @for (int i = 0; i < familyYears.Active.PersonCount; i++) {
                                     var person = familyYears.Active.People[i];
                                     var haveHDHPid = "eligible-" + i;
-                                    var over55id = "over55-" + i;
                                     <p><b>Person @(i+1):</b> </p>
 
                                     <EditForm Model="person" style=margin-left:25px>
-                                        <InputCheckbox id=@over55id @bind-Value=person.FiftyFiveOrOver /> <label for=@over55id>55 or older</label><br/><br/>
+                                        <label>Eligible for Catchup Contributions (55 or older):</label> @person.FiftyFiveOrOver<br/><br/>
                                         <InputCheckbox @bind-Value=person.HealthSavingsAccount.Eligible id='@haveHDHPid'/> <label for='@haveHDHPid' style="display:inline">Have high deductible health plan</label><br/><br/>
                                         <fieldset disabled=@person.HealthSavingsAccount.NotEligible style='margin-left:20px'>
                                             <label>Individual/Family:</label>   <select @bind=person.HealthSavingsAccount.Family><option value=None>choose...</option><option value=EmployeeOnly>Employee only</option><option>Family</option></select><br/>
 
-                                            <label>Contribution Limit:</label> $@person.HealthSavingsAccount.Limit<br/><br/>
+                                            <label>Contribution Limit:</label> @formatMoney(person.HealthSavingsAccount.Limit)<br/><br/>
 
                                             @* @if (person.Employer != null) {
                                                 <p>@person.Employer.Company</p>
@@ -317,7 +362,7 @@ saving/@stepPath
                                             <label>@person.FamilyYear.Year Employer Contribution:</label> $<input type=text class=dollar @bind-Value=person.HealthSavingsAccount.EmployerContribution @bind-Value:event=oninput><br/>
                                         </fieldset>
                                         <br/>
-                                        <label>Amount to Save:</label> <span>$</span>@person.HealthSavingsAccount.AmountToSave<br/>
+                                        <label>Amount to Save:</label> @formatMoney(person.HealthSavingsAccount.AmountToSave)<br/>
                                     </EditForm><br/>
                                 }
 
@@ -330,10 +375,10 @@ saving/@stepPath
                                     <label>Tax Filing Status:</label> <select @bind=familyYears.Active.TaxFilingStatus>
                                         <option value=None>choose...</option>
                                         <option>Single</option>
-                                        <option value=HeadOfHousehold>Head of Household</option>
                                         <option value=MarriedFilingJointly>Married filing jointly</option>
                                         <option value=MarriedFilingSeperately>Married filing seperately</option>
                                         <option value=MarriedFilingSeperatelyAndLivingApart>Married filing seperately (and living apart)</option>
+                                        <option value=HeadOfHousehold>Head of Household</option>
                                         </select><br/>
                                     <label>@familyYears.Active.Year Adjusted Gross Income:</label> $<input type=text class=dollar @bind-Value=familyYears.Active.AdjustedGrossIncome @bind-Value:event=oninput /><br/>
                                 </EditForm><br/>
@@ -352,7 +397,7 @@ saving/@stepPath
 
                                         <EditForm Model="person" style=margin-left:25px>
                                             <InputCheckbox @bind-Value=person.EmployerPlan.Eligible id='@eligibleId'/> <label for='@eligibleId'>Eligible for workplace retirement savings</label><br/><br/>
-                                            <InputCheckbox id=@over50id @bind-Value=person.FiftyOrOver /> <label for=@over50id>50 or older</label><br/><br/>
+                                            <label>Eligible for Catchup Contributions (50 or older):</label> @person.FiftyOrOver<br/><br/>
                                             <InputCheckbox id=@existingIRABalance @bind-Value=person.IRA.HasExistingBalance /> <label for=@existingIRABalance>Has IRA with > $0</label><br/><br/>
 
                                             <label><i>Recommended Option:</i></label><br/>
@@ -391,22 +436,21 @@ saving/@stepPath
                                     <label>Tax Filing Status:</label> <select @bind=familyYears.Active.TaxFilingStatus>
                                                 <option value=None>choose...</option>
                                                 <option>Single</option>
-                                                <option value=HeadOfHousehold>Head of Household</option>
                                                 <option value=MarriedFilingJointly>Married filing jointly</option>
                                                 <option value=MarriedFilingSeperately>Married filing seperately</option>
                                                 <option value=MarriedFilingSeperatelyAndLivingApart>Married filing seperately (and living apart)</option>
+                                                <option value=HeadOfHousehold>Head of Household</option>
                                                 </select><br/>
                                 </EditForm><br/>
                                 @for (int i = 0; i < familyYears.Active.PersonCount; i++) {
                                     var person = familyYears.Active.People[i];
                                     var eligibleId = "eligible-" + i;
-                                    var fiftyLabel = "over50-" + i;
                                     <p><b>Person @(i+1):</b> </p>
 
                                     <EditForm Model="person" style=margin-left:25px>
                                         <InputCheckbox @bind-Value=person.EmployerPlan.Eligible id=@eligibleId /> <label for=@eligibleId>Eligible for workplace retirement savings</label><br/><br/>
 
-                                        <InputCheckbox id=@fiftyLabel @bind-Value=person.FiftyOrOver /> <label for=@fiftyLabel>50 or older</label><br/><br/>
+                                        <label>Eligible for Catchup Contributions (50 or older):</label> @person.FiftyOrOver<br/><br/>
 
                                         <label>@person.FamilyYear.Year 401k Total Contribution Allowed:</label> $<span>@person.EmployerPlan.ContributionAllowed</span><br/>
                                         <label>minus Matched Contribution Allowed (step 2):</label> $<span>@person.EmployerPlan.AmountToSaveForMatch</span><br/>
@@ -423,10 +467,10 @@ saving/@stepPath
                                     <label>Tax Filing Status:</label> <select @bind=familyYears.Active.TaxFilingStatus>
                                         <option value=None>choose...</option>
                                         <option>Single</option>
-                                        <option value=HeadOfHousehold>Head of Household</option>
                                         <option value=MarriedFilingJointly>Married filing jointly</option>
                                         <option value=MarriedFilingSeperately>Married filing seperately</option>
                                         <option value=MarriedFilingSeperatelyAndLivingApart>Married filing seperately (and living apart)</option>
+                                        <option value=HeadOfHousehold>Head of Household</option>
                                         </select><br/>
                                 </EditForm><br/>
 
@@ -453,30 +497,30 @@ saving/@stepPath
                             case 10:
                                 <p><b>Worksheet:</b> </p>
                                 <div>
-                                    <i>list of debts (all interest rates):</i><br>
+                                    <i>list of debts (all interest rates):</i><br/><br/>
                                     <EditForm Model="familyYears.Active">
                                         <table>
                                             <thead>
-                                            <th><label>name</label></th>
-                                            <th><label>interest %</label></th>
-                                            <th><label>category</label></th>
-                                            <th><label>total $</label></th>
-                                            <th><label>payoff date</label></th>
+                                            <th style="width:150px"><label>name</label></th>
+                                            <th style="width:120px"><label>total $</label></th>
+                                            <th style="width:100px"><label>interest %</label></th>
+                                            <th><label>rate category</label></th>
                                             <th><label></label></th>
                                             </thead>
-                                            @foreach (var debt in familyYears.Active.Debts) {
-                                                var myDebt = debt;
+                                            @for (var i=0;i<familyYears.Active.Debts.Count;i++) {
+                                                var debt = familyYears.Active.Debts[i];
+                                                int debtBuffer = i;
                                                 <tr>
-                                                <td><input type=text class=dollar @bind-Value=debt.Name @bind-Value:event=oninput /></td>
-                                                <td><input type=text class=dollar @bind-Value=debt.Rate @bind-Value:event=oninput /></td>
+                                                <td><input style=width:100% type=text class=dollar @bind-Value=debt.Name @bind-Value:event=oninput placeholder='description'/></td>
+                                                <td><input style=width:100% type=text class=dollar @bind-Value=debt.Total @bind-Value:event=oninput placeholder='amount owed'/></td>
+                                                <td><input style=width:100% type=text class=dollar @bind-Value=debt.Rate @bind-Value:event=oninput placeholder='rate'/></td>
                                                 <td><span>@debt.Category</span></td>
-                                                <td><input type=text class=dollar @bind-Value=debt.Total @bind-Value:event=oninput /></td>
-                                                <td><input type=text class=dollar @bind-Value=debt.PayoffDate @bind-Value:event=oninput /></td>
-                                                <td><button @onclick=@(() => familyYears.Active.Debts.Remove(myDebt))>@myDebt.Name<span class="oi oi-delete" aria-hidden="true"></span></button></td>
+                                                <td><button @onclick=@(e=>RemoveDebt(e, debtBuffer))>❌ Debt</button></td>
                                                 </tr>
                                             }
                                         </table>
-                                        <button @onclick=addDebt>Add</button>
+                                        <br/>
+                                        <button @onclick=addDebt>➕ Debt</button>
 
                                         <br/><br/>
                                         <label>Amount to Pay-Off (@step.title):</label> <span>$</span>
@@ -498,9 +542,12 @@ saving/@stepPath
                                 </div>
 
                                 @code{
+                                    void RemoveDebt(MouseEventArgs e, int debtIndex) {
+                                        familyYears.Active.Debts.RemoveAt(debtIndex);
+                                    }
                                     void addDebt()
                                     {
-                                        familyYears.Active?.Debts.Add(new Debt() { Name = "new", Rate = 3.0, Total = 5000 });
+                                        familyYears.Active?.Debts.Add(new Debt());
                                     }
                                 }
                             
@@ -523,18 +570,27 @@ saving/@stepPath
         text,
     }
 
+    public string formatMoney(int? amount) 
+    {
+        return String.Format("${0:#,0.##}", amount);
+    }
+    public string formatMoney(double? amount) 
+    {
+        return String.Format("${0:#,0.##}", amount);
+    }
+
     public string GetRecommendedIRAMarkup(Person person) {
         switch(person.IRATypeRecommendation) {
             case IRAType.DeductibleIRAThenBackdoorRoth:
-                return "<span>IRA: $" + person.IRA.AmountToSave + " ($" + person.IRA.DeductionAllowed + " Deductible), then backdoor roth</span>";
+                return "<span>" + formatMoney(person.IRA.AmountToSave) + " in " + person.PossessiveID + " IRA (" + formatMoney(person.IRA.DeductionAllowed) + " Deductible), then backdoor roth</span>";
             case IRAType.DeductibleIRA:
-                return "<span>IRA: $" + person.IRA.AmountToSave + " ($" + person.IRA.DeductionAllowed + " Deductible)</span>";
+                return "<span>" + formatMoney(person.IRA.AmountToSave) + " in " + person.PossessiveID + " IRA (" + formatMoney(person.IRA.DeductionAllowed) + " Deductible)</span>";
             case IRAType.Roth:
-                return "<span>Roth IRA: $" + person.RothIRA.AmountToSave + "</span>";
+                return "<span>" + formatMoney(person.RothIRA.AmountToSave) + " in " + person.PossessiveID + " Roth IRA</span>";
             case IRAType.NondeductibleIRAThenBackdoorRoth:
-                return "<span>IRA: $" + person.IRA.AmountToSave + " ($" + person.IRA.DeductionAllowed + " Deductible), then backdoor roth</span>";
+                return "<span>" + formatMoney(person.IRA.AmountToSave) + " (nondeductible), then backdoor roth</span>";
             case IRAType.NondeductibleIRA:
-                return "<span>IRA: $" + person.IRA.AmountToSave + " ($" + person.IRA.DeductionAllowed + " Deductible)</span>";
+                return "<span>$" + formatMoney(person.IRA.AmountToSave) + " (nondeductible)</span>";
             default:
                 return "<p>do nothing</p>";
         }

--- a/src/Shared/Models/FamilyData/EmergencyFund.cs
+++ b/src/Shared/Models/FamilyData/EmergencyFund.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+
 public class EmergencyFund {
     public int TargetMonths {get;set;} = 3;
     [Required]

--- a/src/Shared/Models/FamilyData/EmergencyFund.cs
+++ b/src/Shared/Models/FamilyData/EmergencyFund.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using System.Globalization;
 
 public class EmergencyFund {
     public int TargetMonths {get;set;} = 3;

--- a/src/Shared/Models/FamilyData/FamilyYear.cs
+++ b/src/Shared/Models/FamilyData/FamilyYear.cs
@@ -12,10 +12,21 @@ public class FamilyYear {
     
     [Required]
     public int PersonCount { get; set; }
-
     public string StateOfResidence { get; set; }
-    
     public int Year { get; private set; }
+    public string? AdditionalBackground { get; set; }
+    private List<string> _Questions;
+    public List<string> Questions
+    {
+        get {
+            if (_Questions == null)
+            {
+                _Questions = new List<string>();
+            }
+
+            return _Questions;
+        }
+    }
 
     private List<Person>? _people;
     public List<Person> People {
@@ -57,6 +68,15 @@ public class FamilyYear {
     }
 
     public int? AdjustedGrossIncome { get; set; }
+    public int? IncomeTaxPaid { get; set; }
+    public int? TaxableToInvest { get; set; }
+    public int? PlannedSavings { 
+        get {
+            int? annualExpenses = EmergencyFund.MonthlyExpenses * 12;
+            int investFromTaxable = TaxableToInvest ?? 0;
+            return AdjustedGrossIncome - IncomeTaxPaid - annualExpenses + investFromTaxable;
+        }
+    }
     public string? FederalMarginalTaxBracket { get; set; }
     public string? StateMarginalTaxBracket { get; set; }
     public EmergencyFund EmergencyFund { get; set; } = new();

--- a/src/Shared/Models/FamilyData/Person.cs
+++ b/src/Shared/Models/FamilyData/Person.cs
@@ -6,8 +6,8 @@ public class Person {
         this.RothIRA = new RothIRA(this);
         this.HealthSavingsAccount = new HealthSavingsAccount(this);
         this.PersonIndex = personIndex;
-        if (this.PersonIndex == 0) { Identifier = "me"; }
-        else { Identifier = "them"; }
+        if (this.PersonIndex == 0) { Identifier = "person 1"; }
+        else { Identifier = "person 2"; }
     }
 
     public Employer.Employer _employer;
@@ -131,6 +131,10 @@ public class Person {
                     return "her";
                 case null:
                     return null;
+                case "person 1":
+                    return "person 1's";
+                case "person 2":
+                    return "person 2's";
                 default:
                     return "undefined";
             }
@@ -138,8 +142,16 @@ public class Person {
     }
 
     public int? Age { get; set; }
-    public bool FiftyOrOver { get; set; }
-    public bool FiftyFiveOrOver { get; set; }
+    public bool FiftyOrOver { 
+        get {
+            return Age >= 50;
+        }
+    }
+    public bool FiftyFiveOrOver { 
+        get {
+            return Age >= 55;
+        }
+    }
 
     public EmployerPlan EmployerPlan { get; set; }
     public HealthSavingsAccount HealthSavingsAccount { get; set; }

--- a/src/wwwroot/data/portfolio-steps.json
+++ b/src/wwwroot/data/portfolio-steps.json
@@ -73,9 +73,18 @@
         "description": ""
     },
     {
+        "step": "additional-background",
+        "title": "Additional Background",
+        "number": 9,
+        "summary": "Give background information to help provide more context",
+        "priority": "",
+        "returns": "",
+        "description": ""
+    },
+    {
         "step": "questions",
         "title": "Questions",
-        "number": 9,
+        "number": 10,
         "summary": "Fill out questions",
         "priority": "",
         "returns": "",


### PR DESCRIPTION
- add portfolio Additional Background section, before Questions
- implement Question data entry
- default person identifier to 'person 1' and 'person 2'
- navigate to "annual saving" when you get to portfolio "contribution" step. (still, ideally, need to help people get back to portfolio review)
- savings: revamped summary page based on portfolio Contributions text format. (big change)
- savings: calculate planned savings based on annual income - taxes - monthlyExpenses x 12 + additionalMoneyFromTaxableAccount (still need to visualize in step context better)
- reordered Head of Household to bottom of Tax Filing Status listboxes.
- fixed formatting to use commas when appropriate in all (i think) places where we display a dollar figure.
- savings: fifty or older, and fifty-five or older, are no longer checkboxes...as we just calculate it now from the ages we now ask for, like portfolio section did.

